### PR TITLE
Fix compilation error for dmd 2.065

### DIFF
--- a/src/zmqd.d
+++ b/src/zmqd.d
@@ -1342,18 +1342,25 @@ struct Message
 {
 @safe:
     /**
-    Initialises an empty $(ZMQ) message.
+    Initialises a $(ZMQ) message of a specified size.
+    Zero size (default) results in empty message.
 
     Throws:
         $(REF ZmqException) if $(ZMQ) reports an error.
     Corresponds_to:
         $(ZMQREF zmq_msg_init())
+        $(ZMQREF zmq_msg_init_size())
     */
-    static Message opCall()
+    static Message opCall(size_t size = 0)
     {
         Message m;
-        if (trusted!zmq_msg_init(&m.m_msg) != 0) {
-            throw new ZmqException;
+        if (size) {
+            if (trusted!zmq_msg_init_size(&m.m_msg, size) != 0)
+                throw new ZmqException;
+        }
+        else {
+            if (trusted!zmq_msg_init(&m.m_msg) != 0)
+                throw new ZmqException;
         }
         m.m_initialized = true;
         return m;
@@ -1364,22 +1371,6 @@ struct Message
     {
         auto msg = Message();
         assert(msg.size == 0);
-    }
-
-    /**
-    Initialises a $(ZMQ) message of a specified size.
-
-    Throws:
-        $(REF ZmqException) if $(ZMQ) reports an error.
-    Corresponds_to:
-        $(ZMQREF zmq_msg_init_size())
-    */
-    this(size_t size)
-    {
-        if (trusted!zmq_msg_init_size(&m_msg, size) != 0) {
-            throw new ZmqException;
-        }
-        m_initialized = true;
     }
 
     ///


### PR DESCRIPTION
opCall has never been actually called because of non-default constructor present, which has become a compile-time error in 2.065
https://d.puremagic.com/issues/show_bug.cgi?id=12124

Can't verify tests as `dub test` does not pass with 2.064 either
